### PR TITLE
bug fix in findPhantom():  was returning NULL when phantomjs not found

### DIFF
--- a/R/thumb.R
+++ b/R/thumb.R
@@ -44,13 +44,15 @@ phantomInstall <- function() {
 
 # similar to webshot
 findPhantom <- function() {
-  phantom <- if(Sys.which("phantomjs") == "") {
-    if(identical(.Platform$OS.type, "windows")) {
-      Sys.which(file.path(Sys.getenv("APPDATA"), "npm", "phantomjs.cmd"))
-    }
-  } else {
-    Sys.which("phantomjs")
-  }
+    
+  phantom <- Sys.which("phantomjs")
 
+  if(Sys.which("phantomjs") == "") {
+    if(identical(.Platform$OS.type, "windows")) {
+      phantom <- Sys.which(file.path(Sys.getenv("APPDATA"), "npm", "phantomjs.cmd"))
+    }
+  }
+  
   phantom
+  
 }


### PR DESCRIPTION
`findPhantom()` was returning `NULL` when `phantomjs` was not found in the path, which then caused `widgetThumbnail()` to return this error during a call to `makeDisplay()`:

    Error in if (phantom == "") { : argument is of length zero