### PR TITLE
bug: nested panel functions don't respect params change

### DIFF
--- a/R/makeDisplay.R
+++ b/R/makeDisplay.R
@@ -125,8 +125,11 @@ makeDisplay <- function(
   }
 
   if(verbose) message("* Validating 'panelFn'...")
-  panelEx <- kvApply(kvExample(data), panelFn)$value
-
+  if(!is.null(params)){
+  	environment(panelFn) = list2env(params)
+  	environment(cogFn) = list2env(params)
+  }
+  panelEx =  kvApply(kvExample(data), panelFn)$value
   cogEx <- validateCogFn(data, cogFn, verbose)
 
   if(is.null(desc) || is.na(desc))


### PR DESCRIPTION
Fix issue https://github.com/tesseradata/trelliscope/issues/119
by forcing params to be the environment for panelFn and cogFn when params is not null


