### PR TITLE
Load global data

### DIFF
--- a/R/copyDisplay.R
+++ b/R/copyDisplay.R
@@ -1,0 +1,46 @@
+#---------------------------------------------------------------------------------
+# Author: Jeremiah Rounds
+# Email: jeremiah.rounds@pnnl.gov
+# Time:  Fri Oct 23 10:16:33 2015
+#---------------------------------------------------------------------------------
+
+
+copyDisplay = function(old_name, new_name, group="common", conn = getOption("vdbConn"), verbose=TRUE){
+	validateVdbConn(conn)
+	#validateNameGroup(new_name, group)  #<--- don't work because validateNameGroup is a macro like funciton with side-effect assignment instead of a return.
+	#validateNameGroup(old_name, group)
+	old_path_info = trelliscope:::validateNameGroup2(old_name, group)
+	new_path_info = trelliscope:::validateNameGroup2(new_name, group)
+	vdbPrefix <- conn$path
+	old_path = file.path(vdbPrefix, "displays",old_path_info$group, old_path_info$name)
+	new_path = file.path(vdbPrefix, "displays",new_path_info$group, new_path_info$name)
+    checkDisplayPath(new_path, verbose)
+	copyVerify = trelliscope:::copy_dir(old_path, new_path)
+	   # Verify the file renaming
+    if(!copyVerify) {
+      stop("Copy files for display were not successfully moved to '", new_path, "'", call. = FALSE)
+    } 
+	select = c("group",
+		"name",
+		"desc", 
+		"n",
+      "panelFnType",
+      "preRender",
+      "dataClass", 
+      "cogClass",
+      "height",
+      "width",
+      "updated",
+      "keySig"
+	)
+	subsetDisplayObj =
+	#we have to update the display object
+	display_path = file.path(new_path, "displayObj.Rdata")
+	e = new.env()
+	load(display_path, envir=e)
+	e$displayObj$name = new_name 
+	displayObj = e$displayObj
+	save(displayObj, file = display_path)
+    updateDisplayList.displayObj(displayObj, conn)
+
+}

--- a/R/makeDisplay.R
+++ b/R/makeDisplay.R
@@ -125,8 +125,11 @@ makeDisplay <- function(
   }
 
   if(verbose) message("* Validating 'panelFn'...")
-  panelEx <- kvApply(kvExample(data), panelFn)$value
-
+  if(!is.null(params)){
+  	environment(panelFn) = list2env(params)
+  	environment(cogFn) = list2env(params)
+  }
+  panelEx =  kvApply(kvExample(data), panelFn)$value
   cogEx <- validateCogFn(data, cogFn, verbose)
 
   if(is.null(desc) || is.na(desc))

--- a/R/makeDisplay.R
+++ b/R/makeDisplay.R
@@ -203,7 +203,7 @@ makeDisplay <- function(
   packages <- c(packages, "trelliscope")
   if(detect.globals)
   	packages <- unique(c(packages, panelGlobals$packages, cogGlobals$packages))
-  globaVarList = list()
+  globalVarList = list()
   if(detect.globals)
   	globalVarList <- c(panelGlobals$vars, cogGlobals$vars)
 

--- a/R/makeDisplay.R
+++ b/R/makeDisplay.R
@@ -28,7 +28,7 @@ if(getRversion() >= "2.15.1") {
 #' @param params a named list of objects external to the input data that are needed in the distributed computing (most should be taken care of automatically such that this is rarely necessary to specify)
 #' @param packages a vector of R package names that contain functions used in \code{panelFn} or \code{cogFn} (most should be taken care of automatically such that this is rarely necessary to specify)
 #' @param control parameters specifying how the backend should handle things (most-likely parameters to \code{rhwatch} in RHIPE) - see \code{\link[datadr]{rhipeControl}} and \code{\link[datadr]{localDiskControl}}
-#'
+#' @param detect.globals  if TRUE params and packages are automatically detected.  
 #' @details Many of the parameters are optional or have defaults.  For several examples, see the documentation at tessera.io: \url{http://tessera.io/docs-trelliscope}
 #'
 #' Panels by default are not pre-rendered. Instead, this function creates a display object and computes and stores the cognostics.  Panels are then rendered on the fly by the Tessera backend and pushed to the Trelliscope viewer as html with the panel images embedded in the html.  If a user would like to pre-render the images for every subset (using \code{preRender = TRUE}), then by default the image files for the panels will be stored to a local disk connection (see \code{\link{localDiskConn}}) inside the VDB directory, organized in subdirectories by group and name of the display.  Optionally, the user can specify the \code{output} parameter to be any valid "kvConnection" object, as long as it is one that persists on disk (e.g. \code{\link{hdfsConn}}).
@@ -65,7 +65,8 @@ makeDisplay <- function(
   keySig = NULL,
   params = NULL,
   packages = NULL,
-  control = NULL
+  control = NULL,
+  detect.globals = TRUE
 ) {
   validateVdbConn(conn)
 
@@ -200,9 +201,11 @@ makeDisplay <- function(
   cogGlobals <- drGetGlobals(cogFn)
 
   packages <- c(packages, "trelliscope")
-  packages <- unique(c(packages, panelGlobals$packages, cogGlobals$packages))
-
-  globalVarList <- c(panelGlobals$vars, cogGlobals$vars)
+  if(detect.globals)
+  	packages <- unique(c(packages, panelGlobals$packages, cogGlobals$packages))
+  globaVarList = list()
+  if(detect.globals)
+  	globalVarList <- c(panelGlobals$vars, cogGlobals$vars)
 
   if(length(params) > 0)
     for(pnm in names(params))

--- a/R/makeDisplay_internals.R
+++ b/R/makeDisplay_internals.R
@@ -33,6 +33,11 @@ validateNameGroup <- function(name, group) {
   assign("group", group, envir = parent.frame())
 
 }
+#to be honest validateNameGroup is a pretty funky idea for a return =)
+validateNameGroup2 = function(name, group){
+	 validateNameGroup(name,group)
+	return(list(name=name, group=group))
+}
 
 ## internal
 validateCogFn <- function(dat, cogFn, verbose = FALSE) {
@@ -144,6 +149,27 @@ checkDisplayPath <- function(displayPrefix, verbose = TRUE) {
   dir.create(displayPrefix, recursive = TRUE)
 }
 
+#Unfortunatley updateDisplayList won't take a displayObj directly so this function translates displayObj
+updateDisplayList.displayObj = function(displayObj, conn){
+	select = c("group",
+		"name",
+		"desc", 
+		"n",
+      "panelFnType",
+      "preRender",
+      "dataClass", 
+      "cogClass",
+      "height",
+      "width",
+      "updated",
+      "keySig"
+	)
+  	select0 = select[which(select %in% names(displayObj))]
+	subsetDisplayObj = displayObj[select0] 
+	selectNA = setdiff(select, names(displayObj))
+	for(n in selectNA) subsetDisplayObj[n] = NA
+    updateDisplayList(subsetDisplayObj, conn)
+}
 ## internal
 updateDisplayList <- function(argList, conn) {
 

--- a/R/makeDisplay_internals.R
+++ b/R/makeDisplay_internals.R
@@ -224,7 +224,7 @@ encodePNG <- function(plotLoc) {
 
 # this seems to be the best cross-platform way to copy directories
 # if to exists it will be deleted
-copy_dir <- function(from, to) {
+copy_dir <- function(from, to, overwrite=TRUE) {
   if(file.exists(to))
     unlink(to, recursive = TRUE)
   ff <- list.files(from, recursive = TRUE, full.names = TRUE)
@@ -232,6 +232,7 @@ copy_dir <- function(from, to) {
   upath <- unique(dirname(ff2))
   for(up in upath)
     suppressWarnings(dir.create(up, recursive = TRUE))
-  all(file.copy(ff, ff2, overwrite = TRUE))
+  all(file.copy(ff, ff2, overwrite = overwrite))
 }
+
 

--- a/R/saveGlobals.R
+++ b/R/saveGlobals.R
@@ -1,0 +1,26 @@
+#---------------------------------------------------------------------------------
+# Author: Jeremiah Rounds
+# Email: jeremiah.rounds@pnnl.gov
+# Time:  Fri Oct 23 15:33:03 2015
+#---------------------------------------------------------------------------------
+
+#' Save global environment data for displays
+#'
+#' Makes data available in the global environment of all displays of a connection in trelliscope
+#'
+#' @param data data of class "ddo" or "ddf" (see \code{\link{ddo}}, \code{\link{ddf}})
+#' @details Useful to avoid bloating individual displays with global variables common to all displays in a data base.
+#' 
+#' @author Jeremiah Rounds
+#'
+#'
+#' @examples
+#' data(iris)
+#' saveGlobals(iris)
+#'
+#' @export
+saveGlobals = function(..., conn=getOption("vdbConn")){
+	validateVdbConn(conn)
+	save(..., file = file.path(conn$path, "globals.Rdata"))
+	
+}

--- a/inst/trelliscopeViewer/server.R
+++ b/inst/trelliscopeViewer/server.R
@@ -26,6 +26,11 @@ if(file.exists(connFile)) {
   vdbPrefix <- vdbConn$path
 }
 
+globalsFile = "globals.Rdata"
+if(file.exists(globalsFile)){
+	load(globalsFile)	
+}
+
 logMsg("vdbPrefix is ", vdbPrefix)
 
 options(vdbShinyPrefix = vdbPrefix)


### PR DESCRIPTION
Gives users a capacity to have one global storage for all displays instead of duplicate global storage in individual displays.

See: https://github.com/tesseradata/trelliscope/issues/130