### PR TITLE
fix dir.exists

### DIFF
--- a/R/saveGlobals.R
+++ b/R/saveGlobals.R
@@ -1,3 +1,12 @@
+
+# Function to avoid dependence on R > 3.2
+dir.exists = function (x) {
+        if(file.exists(x) & file.info(x)$isdir){
+        	return(TRUE)
+        }
+		return(FALSE)
+ }
+
 #' Path to VDB global data storage file
 #'
 #' Returns an appropriate file name to save VDB-wide globals to for use in Trelliscope displays

--- a/inst/trelliscopeViewer/global.R
+++ b/inst/trelliscopeViewer/global.R
@@ -26,6 +26,13 @@ sourceAll <- function(dir) {
 
 sourceFiles <- "data/R"
 
+# Function to avoid dependence on R > 3.2
+dir.exists = function (x) {
+        if(file.exists(x) & file.info(x)$isdir){
+        	return(TRUE)
+        }
+		return(FALSE)
+ }
 if(dir.exists(sourceFiles)) {
 	message("Sourcing data/R")
 	sourceAll(sourceFiles)


### PR DESCRIPTION
When I introduced code into Trelliscope that used dir.exists, I created a dependency on R version > 3.2.

 I have placed a dir.exists function in two spots in the code to create one and avoid that dependency.  I have done limited testing and believe it works.    A maybe better way to go about this is to check for the existence of R version 3.2, but in a couple more R releases (a year or so) you can probably remove the functions anyway.