### PR TITLE
Move shiny dependencies into head tag

### DIFF
--- a/inst/trelliscopeViewer/www/index.html
+++ b/inst/trelliscopeViewer/www/index.html
@@ -54,6 +54,11 @@
     <script src="assets/custom/controls-panel-layout.js"></script>
     <script src="assets/custom/main.js"></script>
 
+    <!-- shiny -->
+    <script src="shared/shiny.js" type="text/javascript"></script>
+    <link rel="stylesheet" type="text/css" href="shared/shiny.css"/>
+    <script src="assets/custom/shiny-trelliscope-io.js" type="text/javascript"></script>
+
   </head>
   <body>
     <!-- <div id="dummyDiv" class="shiny-text-output"></div> -->
@@ -1034,11 +1039,6 @@
   {{/rows}}
 </table>
 </script>
-
-<!-- shiny -->
-<script src="shared/shiny.js" type="text/javascript"></script>
-<link rel="stylesheet" type="text/css" href="shared/shiny.css"/>
-<script src="assets/custom/shiny-trelliscope-io.js" type="text/javascript"></script>
 
   </body>
 </html>


### PR DESCRIPTION
Newer versions of Shiny Server and Connect are intolerant of late
loading of the Shiny object. (Sorry, it never occurred to me that
the shiny JS dependencies would ever be loaded outside of head)